### PR TITLE
Don't force background colors

### DIFF
--- a/log.js
+++ b/log.js
@@ -146,9 +146,9 @@ log.style = {}
 log.levels = {}
 log.disp = {}
 log.addLevel('silly', -Infinity, { inverse: true }, 'sill')
-log.addLevel('verbose', 1000, { fg: 'blue', bg: 'black' }, 'verb')
+log.addLevel('verbose', 1000, { fg: 'blue' }, 'verb')
 log.addLevel('info', 2000, { fg: 'green' })
-log.addLevel('http', 3000, { fg: 'green', bg: 'black' })
-log.addLevel('warn', 4000, { fg: 'black', bg: 'red' }, 'WARN')
-log.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!')
+log.addLevel('http', 3000, { fg: 'green' })
+log.addLevel('warn', 4000, { fg: 'red', inverse: true }, 'WARN')
+log.addLevel('error', 5000, { fg: 'red' }, 'ERR!')
 log.addLevel('silent', Infinity)


### PR DESCRIPTION
For people that use lighter terminal background colors instead of the prevalent black, the log output of npm doesn't look so nice. This is an attempt at fixing it.
