### PR TITLE
fill prefix with date, if enabled and empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Style objects can have the following fields:
 * `bell` {Boolean} Make a noise (This is pretty annoying, probably.)
 * `fillDateIfEmpty` {Boolean} if prefix is empty, fill it with current date. Only for prefix.
 * `useMS` {Boolean} date in prefix is in milliseconds (true) or UTC string (false). Only for prefix.
-* 
+
 # Message Objects
 
 Every log event is emitted with a message object, and the `log.record`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Style objects can have the following fields:
 * `bg` {String} Color for the background
 * `bold`, `inverse`, `underline` {Boolean} Set the associated property
 * `bell` {Boolean} Make a noise (This is pretty annoying, probably.)
-
+* `fillDateIfEmpty` {Boolean} if prefix is empty, fill it with current date. Only for prefix.
+* `useMS` {Boolean} date in prefix is in milliseconds (true) or UTC string (false). Only for prefix.
+* 
 # Message Objects
 
 Every log event is emitted with a message object, and the `log.record`

--- a/log.js
+++ b/log.js
@@ -159,3 +159,20 @@ log.addLevel('http', 3000, { fg: 'green', bg: 'black' })
 log.addLevel('warn', 4000, { fg: 'black', bg: 'yellow' }, 'WARN')
 log.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!')
 log.addLevel('silent', Infinity)
+
+var util = require('util')
+var already;
+log.enhance = function (log) {
+	if (already) return log
+	// use date for each log record
+	util._extend(log.prefixStyle, { fillDateIfEmpty: true, useMS: true })
+
+	// don't need to write '' for each log statement
+	log.info = log.info.bind(undefined, '')
+	log.error = log.error.bind(undefined, '')
+	log.warn = log.warn.bind(undefined, '')
+	log.verbose = log.verbose.bind(undefined, '')
+	log.http = log.http.bind(undefined, '')
+	already = true
+	return log
+}

--- a/log.js
+++ b/log.js
@@ -62,10 +62,12 @@ log.log = function (lvl, prefix, message) {
   if (stack) a.unshift(stack + '\n')
   message = util.format.apply(util, a)
 
-  if (!prefix && this.prefixStyle.fillDateIfEmpty) {
-    // shortest date formatting code, good enough
-    // OR use classic getDay(), getHours() ... methods, with some cfg...
-    prefix = this.prefixStyle.useMS ? Date.now() : (new Date()).toUTCString()
+  if (!prefix) {
+	if (this.prefixStyle.fillDateIfEmpty) {
+		// shortest date formatting code, good enough
+		// OR use classic getDay(), getHours() ... methods, with some cfg...
+		prefix = this.prefixStyle.useMS ? Date.now() : (new Date()).toUTCString()
+	}
   }
   var m = { id: id++,
             level: lvl,

--- a/log.js
+++ b/log.js
@@ -62,6 +62,11 @@ log.log = function (lvl, prefix, message) {
   if (stack) a.unshift(stack + '\n')
   message = util.format.apply(util, a)
 
+  if (!prefix && this.prefixStyle.fillDateIfEmpty) {
+    // shortest date formatting code, good enough
+    // OR use classic getDay(), getHours() ... methods, with some cfg...
+    prefix = this.prefixStyle.useMS ? Date.now() : (new Date()).toUTCString()
+  }
   var m = { id: id++,
             level: lvl,
             prefix: String(prefix || ''),


### PR DESCRIPTION
Date is in milliseconds or UTC string format. 
The behaviour can be modified with two boolean style fields 'fillDateIfEmpty', 'useMS'.

e.g. 
var log = require('npmlog')
log.prefixStyle = { fillDateIfEmpty: true, useMS: true, fg: 'green' }
log.info('', 'show me when it happened');