### PR TITLE
Themes are attached directly to constructor.

### DIFF
--- a/log.js
+++ b/log.js
@@ -32,12 +32,12 @@ log.progressEnabled = false
 var gaugeTheme = undefined
 
 log.enableUnicode = function () {
-  gaugeTheme = gauge.unicode
+  gaugeTheme = Gauge.unicode
   log.gauge.setTheme(gaugeTheme)
 }
 
 log.disableUnicode = function () {
-  gaugeTheme = gauge.ascii
+  gaugeTheme = Gauge.ascii
   log.gauge.setTheme(gaugeTheme)
 }
 


### PR DESCRIPTION
Calling `log.enableUnicode()` was breaking because `gauge` was undefined.

**r:** @iarna