### PR TITLE
Allow 'error' prefix

### DIFF
--- a/log.js
+++ b/log.js
@@ -245,3 +245,6 @@ log.addLevel('http', 3000, { fg: 'green', bg: 'black' })
 log.addLevel('warn', 4000, { fg: 'black', bg: 'yellow' }, 'WARN')
 log.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!')
 log.addLevel('silent', Infinity)
+
+// allow 'error' prefix
+log.on('error', function(){})

--- a/test/basic.js
+++ b/test/basic.js
@@ -24,6 +24,7 @@ var resultExpect =
   '\u001b[0m\u001b[37m\u001b[40mnpm\u001b[0m \u001b[0m\u001b[31m\u001b[40mERR!\u001b[0m \u001b[0m\u001b[35m404\u001b[0m and maybe a stack.\n',
   '\u001b[0m\u001b[37m\u001b[40mnpm\u001b[0m \u001b[0m\u001b[31m\u001b[40mERR!\u001b[0m \u001b[0m\u001b[35m404\u001b[0m \n',
   '\u001b[0m\u001b[37m\u001b[40mnpm\u001b[0m \u001b[0m\u0007noise\u001b[0m\u001b[35m\u001b[0m LOUD NOISES\n',
+  '\u001b[0m\u001b[37m\u001b[40mnpm\u001b[0m \u001b[0m\u0007noise\u001b[0m \u001b[0m\u001b[35merror\u001b[0m erroring\n',
   '\u001b[0m' ]
 
 var logPrefixEventsExpect =
@@ -161,7 +162,12 @@ var logEventsExpect =
     level: 'noise',
     prefix: false,
     message: 'LOUD NOISES',
-    messageRaw: [ 'LOUD NOISES' ] } ]
+    messageRaw: [ 'LOUD NOISES' ] },
+  { id: 23,
+    level: 'noise',
+    prefix: 'error',
+    message: 'erroring',
+    messageRaw: [ 'erroring' ] } ]
 
 var Stream = require('stream').Stream
 var s = new Stream()
@@ -217,6 +223,7 @@ tap.test('basic', function (t) {
                    'and maybe a stack.\n')
   log.addLevel('noise', 10000, {beep: true})
   log.noise(false, 'LOUD NOISES')
+  log.noise('error', 'erroring')
 
   t.deepEqual(result.join('').trim(), resultExpect.join('').trim(), 'result')
   t.deepEqual(log.record, logEventsExpect, 'record')


### PR DESCRIPTION
Prior to this commit, any time you'd log something with `'error'` as the prefix, it would give something like:
 
```
$ node -e "require('npmlog').error('error', 'some kind of error message')"

events.js:87
      throw Error('Uncaught, unspecified "error" event.');
            ^
Error: Uncaught, unspecified "error" event.
    at Error (native)
    at EventEmitter.emit (events.js:87:13)
    at EventEmitter.<anonymous> ($PWD/node_modules/npmlog/log.js:151:22)
    at EventEmitter.<anonymous> ($PWD/node_modules/npmlog/log.js:223:21)
    at [eval]:1:19
    at Object.exports.runInThisContext (vm.js:74:17)
    at Object.<anonymous> ([eval]-wrapper:6:22)
    at Module._compile (module.js:460:26)
    at evalScript (node.js:431:25)
    at startup (node.js:90:7)
```

This is because when there's a prefix, an event is emitted with the prefix as its type, and [`'error'`-type events are treated in a special way](https://github.com/joyent/node/blob/master/lib/events.js#L77-L92).

The quick and easy fix is to add a dummy event listener for `'error'`, so that's what I've done here. Plus a test.

The (reasonable, I think) side effect here is that it that emitted errors won't get thrown on their own.