### PR TITLE
Allow a function as heading

### DIFF
--- a/log.js
+++ b/log.js
@@ -185,7 +185,11 @@ log.emitLog = function (m) {
   this.clearProgress()
   m.message.split(/\r?\n/).forEach(function (line) {
     if (this.heading) {
-      this.write(this.heading, this.headingStyle)
+      if (typeof v === "function") {
+        this.write(this.heading(), this.headingStyle)
+      }else{
+        this.write(this.heading, this.headingStyle)
+      }
       this.write(' ')
     }
     this.write(disp, log.style[m.level])


### PR DESCRIPTION
Yes, you can do:
```javascript
npmlog.heading = 'myprog';
```
However with this you would be able to do the following as well:
```javascript
npmlog.heading = function () {return Date.now().toString()};
```

Implementing an easy way to add timestamps to logs messages like this is a very requested feature by many I know. :+1: 