### PR TITLE
Bring in new are-we-there-yet for perf improvements

### DIFF
--- a/log.js
+++ b/log.js
@@ -100,9 +100,10 @@ log.clearProgress = function () {
   this.gauge.hide()
 }
 
-log.showProgress = function (name) {
+log.showProgress = function (name, completed) {
   if (!this.progressEnabled) return
-  this.gauge.show(name, this.tracker.completed())
+  if (completed == null) completed = this.tracker.completed()
+  this.gauge.show(name, completed)
 }.bind(log) // bind for use in tracker's on-change listener
 
 // temporarily stop emitting, but don't drop

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "ansi": "~0.3.1",
-    "are-we-there-yet": "~1.0.6",
+    "are-we-there-yet": "~1.1.2",
     "gauge": "~1.2.5"
   },
   "devDependencies": {

--- a/test/progress.js
+++ b/test/progress.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var test = require('tap').test
+var Progress = require('are-we-there-yet')
 var log = require('../log.js')
 
 var actions = []
@@ -38,9 +39,18 @@ function didActions(t, msg, output) {
   actions = []
 }
 
+function resetTracker() {
+  log.disableProgress()
+  log.tracker = new Progress.TrackerGroup()
+  log.enableProgress()
+  actions = []
+}
 
 test('enableProgress', function (t) {
   t.plan(6)
+  resetTracker()
+  log.disableProgress()
+  actions = []
   log.enableProgress()
   didActions(t, 'enableProgress', [ [ 'enable' ], [ 'show', undefined, 0 ] ])
   log.enableProgress()
@@ -49,6 +59,7 @@ test('enableProgress', function (t) {
 
 test('disableProgress', function (t) {
   t.plan(4)
+  resetTracker()
   log.disableProgress()
   didActions(t, 'disableProgress', [ [ 'hide' ], [ 'disable' ] ])
   log.disableProgress()
@@ -57,6 +68,9 @@ test('disableProgress', function (t) {
 
 test('showProgress', function (t) {
   t.plan(5)
+  resetTracker()
+  log.disableProgress()
+  actions = []
   log.showProgress('foo')
   didActions(t, 'showProgress disabled', [])
   log.enableProgress()
@@ -67,6 +81,7 @@ test('showProgress', function (t) {
 
 test('clearProgress', function (t) {
   t.plan(3)
+  resetTracker()
   log.clearProgress()
   didActions(t, 'clearProgress', [ [ 'hide' ] ])
   log.disableProgress()
@@ -77,7 +92,7 @@ test('clearProgress', function (t) {
 
 test("newItem", function (t) {
   t.plan(12)
-  log.enableProgress()
+  resetTracker()
   actions = []
   var a = log.newItem("test", 10)
   didActions(t, "newItem", [ [ 'show', 'test', 0 ] ])
@@ -90,24 +105,26 @@ test("newItem", function (t) {
 // test that log objects proxy through. And test that completion status filters up
 test("newGroup", function (t) {
   t.plan(23)
+  resetTracker()
   var a = log.newGroup("newGroup")
-  didActions(t, "newGroup", [ [ 'show', 'newGroup', 0.5 ] ])
+  didActions(t, 'newGroup', [[ 'show', 'newGroup', 0 ]])
   a.warn("test", "this is a test")
-  didActions(t, "newGroup:warn", [ [ 'pulse', 'test' ], [ 'hide' ], [ 'show', undefined, 0.5 ] ])
+  didActions(t, "newGroup:warn", [ [ 'pulse', 'test' ], [ 'hide' ], [ 'show', undefined, 0 ] ])
   var b = a.newItem("newGroup2", 10)
-  didActions(t, "newGroup:newItem", [ [ 'show', 'newGroup2', 0.5 ] ])
+  didActions(t, "newGroup:newItem", [ [ 'show', 'newGroup2', 0 ] ])
   b.completeWork(5)
-  didActions(t, "newGroup:completeWork", [ [ 'show', 'newGroup2', 0.75 ] ])
+  didActions(t, "newGroup:completeWork", [ [ 'show', 'newGroup2', 0.5] ])
   a.finish()
   didActions(t, "newGroup:finish", [ [ 'show', 'newGroup', 1 ] ])
 })
 
 test("newStream", function (t) {
   t.plan(13)
+  resetTracker()
   var a = log.newStream("newStream", 10)
-  didActions(t, "newStream", [ [ 'show', 'newStream', 0.6666666666666666 ] ])
+  didActions(t, "newStream", [ [ 'show', 'newStream', 0 ] ])
   a.write("abcde")
-  didActions(t, "newStream", [ [ 'show', 'newStream', 0.8333333333333333 ] ])
+  didActions(t, "newStream", [ [ 'show', 'newStream', 0.5 ] ])
   a.write("fghij")
   didActions(t, "newStream", [ [ 'show', 'newStream', 1 ] ])
   t.is(log.tracker.completed(), 1, "Overall completion")

--- a/test/progress.js
+++ b/test/progress.js
@@ -80,7 +80,7 @@ test("newItem", function (t) {
   log.enableProgress()
   actions = []
   var a = log.newItem("test", 10)
-  didActions(t, "newItem", [ [ 'show', undefined, 0 ] ])
+  didActions(t, "newItem", [ [ 'show', 'test', 0 ] ])
   a.completeWork(5)
   didActions(t, "newItem:completeWork", [ [ 'show', 'test', 0.5 ] ])
   a.finish()
@@ -91,11 +91,11 @@ test("newItem", function (t) {
 test("newGroup", function (t) {
   t.plan(23)
   var a = log.newGroup("newGroup")
-  didActions(t, "newGroup", [ [ 'show', undefined, 0.5 ] ])
+  didActions(t, "newGroup", [ [ 'show', 'newGroup', 0.5 ] ])
   a.warn("test", "this is a test")
   didActions(t, "newGroup:warn", [ [ 'pulse', 'test' ], [ 'hide' ], [ 'show', undefined, 0.5 ] ])
   var b = a.newItem("newGroup2", 10)
-  didActions(t, "newGroup:newItem", [ [ 'show', 'newGroup', 0.5 ] ])
+  didActions(t, "newGroup:newItem", [ [ 'show', 'newGroup2', 0.5 ] ])
   b.completeWork(5)
   didActions(t, "newGroup:completeWork", [ [ 'show', 'newGroup2', 0.75 ] ])
   a.finish()
@@ -105,7 +105,7 @@ test("newGroup", function (t) {
 test("newStream", function (t) {
   t.plan(13)
   var a = log.newStream("newStream", 10)
-  didActions(t, "newStream", [ [ 'show', undefined, 0.6666666666666666 ] ])
+  didActions(t, "newStream", [ [ 'show', 'newStream', 0.6666666666666666 ] ])
   a.write("abcde")
   didActions(t, "newStream", [ [ 'show', 'newStream', 0.8333333333333333 ] ])
   a.write("fghij")


### PR DESCRIPTION
This PR is made up of 4 commits;

* 74853e7 are-we-there-yet@1.1.2 (the module update)
  * Rewrite how `completed()` works to keep track as we go instead of doing a giant tree walk.
  * Add cycle detection (it explodes if you try to do this) and tests for that.
* f498b46 Fix tests now that are-we-there-yet emits the right names
  * Updating `are-we-there-yet` broke our tests, as the tests were relying on buggy behavior– previously `are-we-there-yet` was not emitting the name of the thing that changed (it seems to have been emitting the name of its parent).
* fa8e7a1 Make tests work with their own tracker objects
  * This is important, as it makes it so that the tests don't depend on each other any more.
* 7bfbfb1 Take advantage of new are-we-there-yet features
  * Calls to `completed()` are cheap now, but we don't even need those.
