### PR TITLE
Fix the `--no-progress` bugs in npm

### DIFF
--- a/log.js
+++ b/log.js
@@ -52,8 +52,9 @@ log.gauge = new Gauge(stream, {
 
 log.tracker = new Progress.TrackerGroup()
 
-// no progress bars unless asked
-log.progressEnabled = false
+// we track this separately as we may need to temporarily disable the
+// display of the status bar for our own loggy purposes.
+log.progressEnabled = log.gauge.isEnabled()
 
 var unicodeEnabled
 

--- a/log.js
+++ b/log.js
@@ -82,12 +82,10 @@ log.enableProgress = function () {
   if (this._pause) return
   this.tracker.on('change', this.showProgress)
   this.gauge.enable()
-  this.showProgress()
 }
 
 log.disableProgress = function () {
   if (!this.progressEnabled) return
-  this.clearProgress()
   this.progressEnabled = false
   this.tracker.removeListener('change', this.showProgress)
   this.gauge.disable()

--- a/log.js
+++ b/log.js
@@ -79,8 +79,8 @@ log.setGaugeTemplate = function (template) {
 log.enableProgress = function () {
   if (this.progressEnabled) return
   this.progressEnabled = true
-  if (this._pause) return
   this.tracker.on('change', this.showProgress)
+  if (this._pause) return
   this.gauge.enable()
 }
 
@@ -147,6 +147,7 @@ log.showProgress = function (name, completed) {
 // temporarily stop emitting, but don't drop
 log.pause = function () {
   this._paused = true
+  if (this.progressEnabled) this.gauge.disable()
 }
 
 log.resume = function () {
@@ -158,7 +159,7 @@ log.resume = function () {
   b.forEach(function (m) {
     this.emitLog(m)
   }, this)
-  if (this.progressEnabled) this.enableProgress()
+  if (this.progressEnabled) this.gauge.enable()
 }
 
 log._buffer = []

--- a/log.js
+++ b/log.js
@@ -39,6 +39,7 @@ log.disableColor = function () {
 log.level = 'info'
 
 log.gauge = new Gauge(stream, {
+  enabled: false, // no progress bars unless asked
   theme: {hasColor: log.useColor()},
   template: [
     {type: 'progressbar', length: 20},

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "are-we-there-yet": "~1.1.2",
     "console-control-strings": "~1.1.0",
-    "gauge": "~2.6.0",
+    "gauge": "~2.7.1",
     "set-blocking": "~2.0.0"
   },
   "devDependencies": {

--- a/test/progress.js
+++ b/test/progress.js
@@ -71,21 +71,21 @@ function resetTracker () {
 }
 
 test('enableProgress', function (t) {
-  t.plan(7)
+  t.plan(4)
   resetTracker()
   log.disableProgress()
   actions = []
   log.enableProgress()
-  didActions(t, 'enableProgress', [ [ 'enable' ], [ 'show', {completed: 0} ] ])
+  didActions(t, 'enableProgress', [ [ 'enable' ] ])
   log.enableProgress()
   didActions(t, 'enableProgress again', [])
 })
 
 test('disableProgress', function (t) {
-  t.plan(6)
+  t.plan(4)
   resetTracker()
   log.disableProgress()
-  didActions(t, 'disableProgress', [ [ 'hide' ], [ 'disable' ] ])
+  didActions(t, 'disableProgress', [ [ 'disable' ] ])
   log.disableProgress()
   didActions(t, 'disableProgress again', [])
 })

--- a/test/progress.js
+++ b/test/progress.js
@@ -6,11 +6,17 @@ var log = require('../log.js')
 
 var actions = []
 log.gauge = {
+  enabled: false,
   enable: function () {
+    this.enabled = true
     actions.push(['enable'])
   },
   disable: function () {
+    this.enabled = false
     actions.push(['disable'])
+  },
+  isEnabled: function () {
+    return this.enabled
   },
   hide: function () {
     actions.push(['hide'])


### PR DESCRIPTION
They were a result of `log.progressEnabled` getting out of sync with `gauge`'s own internal ideas about its enabledness.
