### PR TITLE
Added check for log.gauge.isEnabled

### DIFF
--- a/log.js
+++ b/log.js
@@ -52,9 +52,14 @@ log.gauge = new Gauge(stream, {
 
 log.tracker = new Progress.TrackerGroup()
 
-// we track this separately as we may need to temporarily disable the
-// display of the status bar for our own loggy purposes.
-log.progressEnabled = log.gauge.isEnabled()
+if (log.gauge.isEnabled) {
+  // we track this separately as we may need to temporarily disable the
+  // display of the status bar for our own loggy purposes.
+  log.progressEnabled = log.gauge.isEnabled()
+} else {
+  // older versions of gauge do not have isEnabled, and some dependency graphs resolve to it
+  // see https://github.com/npm/npmlog/issues/48
+}
 
 var unicodeEnabled
 


### PR DESCRIPTION
Older versions of gauge do not have isEnabled, and some dependency graphs resolve to it. Fixes #48.

I don't like checking for previous versions of the API but I'm also tired of getting giant error stacks every time I install via `yarn`. Short of updating the `gauge` version in everybody who uses it _(if only!)_, there doesn't seem to be any other way to fix 48. 😢