### PR TITLE
chore: fix a ridiculous issue

### DIFF
--- a/log.js
+++ b/log.js
@@ -228,8 +228,9 @@ log.emitLog = function (m) {
   var disp = log.disp[m.level] != null ? log.disp[m.level] : m.level
   this.clearProgress()
   m.message.split(/\r?\n/).forEach(function (line) {
-    if (this.heading) {
-      this.write(this.heading, this.headingStyle)
+    var heading = this.heading;
+    if (heading) {
+      this.write(heading, this.headingStyle)
       this.write(' ')
     }
     this.write(disp, log.style[m.level])


### PR DESCRIPTION
It's seems nothing changed, but it would be very helpful if you can accept this changes.

Here is the reason:

I'm looking for a way to support timestamp in `npmlog` and I found this: https://github.com/npm/npmlog/issues/33#issuecomment-342785666. And it work perfect.

But I did a little bit changes on it, trying to log the time delta.
The code like this:

```javascript
let last = 0;
Object.defineProperty(log, 'heading', { 
  get: () => { 
    const d = new Date();
    const now = d.getTime();
    const cost = String(last === 0 ? 0 : (now - last));
    last = now;
    const hh = String(d.getHours()).padStart(2, '0');
    const mm = String(d.getMinutes()).padStart(2, '0');
    const ss = String(d.getSeconds()).padStart(2, '0');
    const ms = String(d.getMilliseconds()).padStart(4, '0');
    return `${hh}:${mm}:${ss}.${ms} +${cost}ms`;
  }
})
```
Finally I found, the `cost` is always be `0`.
When I look at the source code, I found the reason, which because it use `this.heading` twice. 

So I made this pull request to  fix it.
Nothing hurt, but it's really helpful for my code.
Thanks
