### PR TITLE
perf: rewrite npmlog

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,400 +1,468 @@
-'use strict'
-var Progress = require('are-we-there-yet')
-var Gauge = require('gauge')
-var EE = require('events').EventEmitter
-var log = exports = module.exports = new EE()
-var util = require('util')
-
+var { EventEmitter } = require('events')
 var setBlocking = require('set-blocking')
 var consoleControl = require('console-control-strings')
+var util = require('util')
 
 setBlocking(true)
-var stream = process.stderr
-Object.defineProperty(log, 'stream', {
-  set: function (newStream) {
-    stream = newStream
-    if (this.gauge) {
-      this.gauge.setWriteTo(stream, stream)
-    }
-  },
-  get: function () {
-    return stream
-  },
-})
-
-// by default, decide based on tty-ness.
-var colorEnabled
-log.useColor = function () {
-  return colorEnabled != null ? colorEnabled : stream.isTTY
-}
-
-log.enableColor = function () {
-  colorEnabled = true
-  this.gauge.setTheme({ hasColor: colorEnabled, hasUnicode: unicodeEnabled })
-}
-log.disableColor = function () {
-  colorEnabled = false
-  this.gauge.setTheme({ hasColor: colorEnabled, hasUnicode: unicodeEnabled })
-}
-
-// default level
-log.level = 'info'
-
-log.gauge = new Gauge(stream, {
-  enabled: false, // no progress bars unless asked
-  theme: { hasColor: log.useColor() },
-  template: [
-    { type: 'progressbar', length: 20 },
-    { type: 'activityIndicator', kerning: 1, length: 1 },
-    { type: 'section', default: '' },
-    ':',
-    { type: 'logline', kerning: 1, default: '' },
-  ],
-})
-
-log.tracker = new Progress.TrackerGroup()
-
-// we track this separately as we may need to temporarily disable the
-// display of the status bar for our own loggy purposes.
-log.progressEnabled = log.gauge.isEnabled()
-
-var unicodeEnabled
-
-log.enableUnicode = function () {
-  unicodeEnabled = true
-  this.gauge.setTheme({ hasColor: this.useColor(), hasUnicode: unicodeEnabled })
-}
-
-log.disableUnicode = function () {
-  unicodeEnabled = false
-  this.gauge.setTheme({ hasColor: this.useColor(), hasUnicode: unicodeEnabled })
-}
-
-log.setGaugeThemeset = function (themes) {
-  this.gauge.setThemeset(themes)
-}
-
-log.setGaugeTemplate = function (template) {
-  this.gauge.setTemplate(template)
-}
-
-log.enableProgress = function () {
-  if (this.progressEnabled || this._paused) {
-    return
-  }
-
-  this.progressEnabled = true
-  this.tracker.on('change', this.showProgress)
-  this.gauge.enable()
-}
-
-log.disableProgress = function () {
-  if (!this.progressEnabled) {
-    return
-  }
-  this.progressEnabled = false
-  this.tracker.removeListener('change', this.showProgress)
-  this.gauge.disable()
-}
 
 var trackerConstructors = ['newGroup', 'newItem', 'newStream']
 
-var mixinLog = function (tracker) {
-  // mixin the public methods from log into the tracker
-  // (except: conflicts and one's we handle specially)
-  Object.keys(log).forEach(function (P) {
-    if (P[0] === '_') {
-      return
-    }
+class Log extends EventEmitter {
+  #stream = process.stderr
+  #gauge = undefined
+  #colorEnabled = false
+  #unicodeEnabled = false
+  #id = 0
+  #tracker = undefined
+  #hasColor = undefined
+  #hasUnicode = undefined
 
-    if (trackerConstructors.filter(function (C) {
-      return C === P
-    }).length) {
-      return
-    }
+  constructor () {
+    super()
 
-    if (tracker[P]) {
-      return
-    }
+    // default level
+    this.level = 'info'
+    // we track this separately as we may need to temporarily disable the
+    // display of the status bar for our own loggy purposes.
+    this.progressEnabled = false
+    this._paused = false
+    // bind for use in tracker's on-change listener
+    this.showProgress = this.showProgress.bind(this)
+    this._buffer = []
+    this.record = []
+    this.maxRecordSize = 10000
+    this.log = this.log.bind(this)
 
-    if (typeof log[P] !== 'function') {
-      return
-    }
+    this.prefixStyle = { fg: 'magenta' }
+    this.headingStyle = { fg: 'white', bg: 'black' }
 
-    var func = log[P]
-    tracker[P] = function () {
-      return func.apply(log, arguments)
-    }
-  })
-  // if the new tracker is a group, make sure any subtrackers get
-  // mixed in too
-  if (tracker instanceof Progress.TrackerGroup) {
-    trackerConstructors.forEach(function (C) {
-      var func = tracker[C]
-      tracker[C] = function () {
-        return mixinLog(func.apply(tracker, arguments))
-      }
+    this.style = {}
+    this.levels = {}
+    this.disp = {}
+
+    this.addLevel('silly', -Infinity, { inverse: true }, 'sill')
+    this.addLevel('verbose', 1000, { fg: 'cyan', bg: 'black' }, 'verb')
+    this.addLevel('info', 2000, { fg: 'green' })
+    this.addLevel('timing', 2500, { fg: 'green', bg: 'black' })
+    this.addLevel('http', 3000, { fg: 'green', bg: 'black' })
+    this.addLevel('notice', 3500, { fg: 'cyan', bg: 'black' })
+    this.addLevel('warn', 4000, { fg: 'black', bg: 'yellow' }, 'WARN')
+    this.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!')
+    this.addLevel('silent', Infinity)
+
+    // allow 'error' prefix
+    this.on('error', function () { })
+
+    Object.defineProperty(this, 'tracker', {
+      get: () => {
+        if (!this.#tracker) {
+          const Progress = require('are-we-there-yet')
+          this.#tracker = new Progress.TrackerGroup()
+        }
+
+        return this.#tracker
+      },
+      set: (tracker) => {
+        this.#tracker = tracker
+      },
+      enumerable: true,
+      configurable: true,
     })
   }
-  return tracker
-}
 
-// Add tracker constructors to the top level log object
-trackerConstructors.forEach(function (C) {
-  log[C] = function () {
-    return mixinLog(this.tracker[C].apply(this.tracker, arguments))
-  }
-})
+  set stream (newStream) {
+    this.#stream = newStream
 
-log.clearProgress = function (cb) {
-  if (!this.progressEnabled) {
-    return cb && process.nextTick(cb)
-  }
-
-  this.gauge.hide(cb)
-}
-
-log.showProgress = function (name, completed) {
-  if (!this.progressEnabled) {
-    return
-  }
-
-  var values = {}
-  if (name) {
-    values.section = name
-  }
-
-  var last = log.record[log.record.length - 1]
-  if (last) {
-    values.subsection = last.prefix
-    var disp = log.disp[last.level]
-    var logline = this._format(disp, log.style[last.level])
-    if (last.prefix) {
-      logline += ' ' + this._format(last.prefix, this.prefixStyle)
+    if (this.#gauge) {
+      this.#gauge.setWriteTo(newStream, newStream)
     }
-
-    logline += ' ' + last.message.split(/\r?\n/)[0]
-    values.logline = logline
-  }
-  values.completed = completed || this.tracker.completed()
-  this.gauge.show(values)
-}.bind(log) // bind for use in tracker's on-change listener
-
-// temporarily stop emitting, but don't drop
-log.pause = function () {
-  this._paused = true
-  if (this.progressEnabled) {
-    this.gauge.disable()
-  }
-}
-
-log.resume = function () {
-  if (!this._paused) {
-    return
   }
 
-  this._paused = false
-
-  var b = this._buffer
-  this._buffer = []
-  b.forEach(function (m) {
-    this.emitLog(m)
-  }, this)
-  if (this.progressEnabled) {
-    this.gauge.enable()
-  }
-}
-
-log._buffer = []
-
-var id = 0
-log.record = []
-log.maxRecordSize = 10000
-log.log = function (lvl, prefix, message) {
-  var l = this.levels[lvl]
-  if (l === undefined) {
-    return this.emit('error', new Error(util.format(
-      'Undefined log level: %j', lvl)))
+  get stream () {
+    return this.#stream
   }
 
-  var a = new Array(arguments.length - 2)
-  var stack = null
-  for (var i = 2; i < arguments.length; i++) {
-    var arg = a[i - 2] = arguments[i]
-
-    // resolve stack traces to a plain string.
-    if (typeof arg === 'object' && arg instanceof Error && arg.stack) {
-      Object.defineProperty(arg, 'stack', {
-        value: stack = arg.stack + '',
-        enumerable: true,
-        writable: true,
+  get gauge () {
+    if (!this.#gauge) {
+      const Gauge = require('gauge')
+      this.#gauge = new Gauge(this.#stream, {
+        enabled: false, // no progress bars unless asked
+        theme: {
+          hasColor: this.#hasColor !== undefined
+            ? this.#hasColor
+            : this.useColor(),
+          hasUnicode: this.#hasUnicode,
+        },
+        template: [
+          { type: 'progressbar', length: 20 },
+          { type: 'activityIndicator', kerning: 1, length: 1 },
+          { type: 'section', default: '' },
+          ':',
+          { type: 'logline', kerning: 1, default: '' },
+        ],
       })
     }
-  }
-  if (stack) {
-    a.unshift(stack + '\n')
-  }
-  message = util.format.apply(util, a)
 
-  var m = {
-    id: id++,
-    level: lvl,
-    prefix: String(prefix || ''),
-    message: message,
-    messageRaw: a,
+    return this.#gauge
   }
 
-  this.emit('log', m)
-  this.emit('log.' + lvl, m)
-  if (m.prefix) {
-    this.emit(m.prefix, m)
+  set gauge (newGauge) {
+    this.#gauge = newGauge
   }
 
-  this.record.push(m)
-  var mrs = this.maxRecordSize
-  var n = this.record.length - mrs
-  if (n > mrs / 10) {
-    var newSize = Math.floor(mrs * 0.9)
-    this.record = this.record.slice(-1 * newSize)
+  // by default, decide based on tty-ness.
+  useColor () {
+    return this.#colorEnabled != null ? this.#colorEnabled : this.#stream.isTTY
   }
 
-  this.emitLog(m)
-}.bind(log)
-
-log.emitLog = function (m) {
-  if (this._paused) {
-    this._buffer.push(m)
-    return
-  }
-  if (this.progressEnabled) {
-    this.gauge.pulse(m.prefix)
+  enableColor () {
+    this.#colorEnabled = true
+    this.#gaugeSetTheme(this.#colorEnabled, this.#unicodeEnabled)
   }
 
-  var l = this.levels[m.level]
-  if (l === undefined) {
-    return
+  disableColor () {
+    this.#colorEnabled = false
+    this.#gaugeSetTheme(this.#colorEnabled, this.#unicodeEnabled)
   }
 
-  if (l < this.levels[this.level]) {
-    return
-  }
-
-  if (l > 0 && !isFinite(l)) {
-    return
-  }
-
-  // If 'disp' is null or undefined, use the lvl as a default
-  // Allows: '', 0 as valid disp
-  var disp = log.disp[m.level]
-  this.clearProgress()
-  m.message.split(/\r?\n/).forEach(function (line) {
-    var heading = this.heading
-    if (heading) {
-      this.write(heading, this.headingStyle)
-      this.write(' ')
-    }
-    this.write(disp, log.style[m.level])
-    var p = m.prefix || ''
-    if (p) {
-      this.write(' ')
+  #gaugeSetTheme (hasColor, hasUnicode) {
+    if (!this.#gauge) {
+      this.#hasColor = hasColor
+      this.#hasUnicode = hasUnicode
+      return
     }
 
-    this.write(p, this.prefixStyle)
-    this.write(' ' + line + '\n')
-  }, this)
-  this.showProgress()
-}
-
-log._format = function (msg, style) {
-  if (!stream) {
-    return
+    this.#gauge.setTheme({
+      hasColor,
+      hasUnicode,
+    })
   }
 
-  var output = ''
-  if (this.useColor()) {
-    style = style || {}
-    var settings = []
-    if (style.fg) {
-      settings.push(style.fg)
-    }
-
-    if (style.bg) {
-      settings.push('bg' + style.bg[0].toUpperCase() + style.bg.slice(1))
-    }
-
-    if (style.bold) {
-      settings.push('bold')
-    }
-
-    if (style.underline) {
-      settings.push('underline')
-    }
-
-    if (style.inverse) {
-      settings.push('inverse')
-    }
-
-    if (settings.length) {
-      output += consoleControl.color(settings)
-    }
-
-    if (style.beep) {
-      output += consoleControl.beep()
-    }
-  }
-  output += msg
-  if (this.useColor()) {
-    output += consoleControl.color('reset')
+  enableUnicode () {
+    this.#unicodeEnabled = true
+    this.#gaugeSetTheme(this.useColor(), this.#unicodeEnabled)
   }
 
-  return output
-}
-
-log.write = function (msg, style) {
-  if (!stream) {
-    return
+  disableUnicode () {
+    this.#unicodeEnabled = false
+    this.#gaugeSetTheme(this.useColor(), this.#unicodeEnabled)
   }
 
-  stream.write(this._format(msg, style))
-}
-
-log.addLevel = function (lvl, n, style, disp) {
-  // If 'disp' is null or undefined, use the lvl as a default
-  if (disp == null) {
-    disp = lvl
+  setGaugeThemeset (themes) {
+    this.gauge.setThemeset(themes)
   }
 
-  this.levels[lvl] = n
-  this.style[lvl] = style
-  if (!this[lvl]) {
-    this[lvl] = function () {
-      var a = new Array(arguments.length + 1)
-      a[0] = lvl
-      for (var i = 0; i < arguments.length; i++) {
-        a[i + 1] = arguments[i]
+  setGaugeTemplate (template) {
+    this.gauge.setTemplate(template)
+  }
+
+  enableProgress () {
+    if (this.progressEnabled || this._paused) {
+      return
+    }
+
+    this.progressEnabled = true
+    this.tracker.on('change', this.showProgress)
+    this.gauge.enable()
+  }
+
+  disableProgress () {
+    if (!this.progressEnabled) {
+      return
+    }
+
+    this.progressEnabled = false
+    this.tracker.removeListener('change', this.showProgress)
+    this.gauge.disable()
+  }
+
+  newGroup (groupname, weight) {
+    return this.#mixingLog(
+      this.tracker.newGroup(groupname, weight)
+    )
+  }
+
+  newItem (name, todo, weight) {
+    return this.#mixingLog(
+      this.tracker.newItem(name, todo, weight)
+    )
+  }
+
+  newStream (name, todo, weight) {
+    return this.#mixingLog(
+      this.tracker.newStream(name, todo, weight)
+    )
+  }
+
+  #mixingLog (tracker) {
+    // mixin the public methods from log into the tracker
+    // (except: conflicts and one's we handle specially)
+    Object.keys(this).forEach((P) => {
+      if (P[0] === '_') {
+        return
       }
 
-      return this.log.apply(this, a)
-    }.bind(this)
+      if (trackerConstructors.filter(function (C) {
+        return C === P
+      }).length) {
+        return
+      }
+
+      if (tracker[P]) {
+        return
+      }
+
+      if (typeof this[P] !== 'function') {
+        return
+      }
+
+      var func = this[P]
+      tracker[P] = (...args) => {
+        return func.apply(this, args)
+      }
+    })
+
+    const Progress = require('are-we-there-yet')
+    // if the new tracker is a group, make sure any subtrackers get
+    // mixed in too
+    if (tracker instanceof Progress.TrackerGroup) {
+      trackerConstructors.forEach((C) => {
+        var func = tracker[C]
+        tracker[C] = (...args) => {
+          return this.#mixingLog(func.apply(tracker, args))
+        }
+      })
+    }
+
+    return tracker
   }
-  this.disp[lvl] = disp
+
+  clearProgress (cb) {
+    if (!this.progressEnabled) {
+      return cb && process.nextTick(cb)
+    }
+
+    this.gauge.hide(cb)
+  }
+
+  showProgress (name, completed) {
+    if (!this.progressEnabled) {
+      return
+    }
+
+    var values = {}
+    if (name) {
+      values.section = name
+    }
+
+    var last = this.record[this.record.length - 1]
+    if (last) {
+      values.subsection = last.prefix
+      var disp = this.disp[last.level]
+      var logline = this._format(disp, this.style[last.level])
+      if (last.prefix) {
+        logline += ' ' + this._format(last.prefix, this.prefixStyle)
+      }
+
+      logline += ' ' + last.message.split(/\r?\n/)[0]
+      values.logline = logline
+    }
+    values.completed = completed || this.tracker.completed()
+    this.gauge.show(values)
+  }
+
+  pause () {
+    this._paused = true
+    if (this.progressEnabled) {
+      this.gauge.disable()
+    }
+  }
+
+  resume () {
+    if (!this._paused) {
+      return
+    }
+
+    this._paused = false
+
+    var b = this._buffer
+    this._buffer = []
+
+    b.forEach(function (m) {
+      this.emitLog(m)
+    }, this)
+
+    if (this.progressEnabled) {
+      this.gauge.enable()
+    }
+  }
+
+  log (lvl, prefix, ...args) {
+    var l = this.levels[lvl]
+    if (l === undefined) {
+      return this.emit('error', new Error(util.format(
+        'Undefined log level: %j', lvl)))
+    }
+
+    var message = args[2]
+    var stack = null
+    for (var i = 0; i < args.length; i++) {
+      var arg = args[i]
+
+      // resolve stack traces to a plain string.
+      if (typeof arg === 'object' && arg instanceof Error && arg.stack) {
+        Object.defineProperty(arg, 'stack', {
+          value: stack = arg.stack + '',
+          enumerable: true,
+          writable: true,
+        })
+      }
+    }
+    if (stack) {
+      args.unshift(stack + '\n')
+    }
+    message = util.format.apply(util, args)
+
+    var m = {
+      id: this.#id++,
+      level: lvl,
+      prefix: String(prefix || ''),
+      message: message,
+      messageRaw: args,
+    }
+
+    this.emit('log', m)
+    this.emit('log.' + lvl, m)
+    if (m.prefix) {
+      this.emit(m.prefix, m)
+    }
+
+    this.record.push(m)
+    var mrs = this.maxRecordSize
+    var n = this.record.length - mrs
+    if (n > mrs / 10) {
+      var newSize = Math.floor(mrs * 0.9)
+      this.record = this.record.slice(-1 * newSize)
+    }
+
+    this.emitLog(m)
+  }
+
+  emitLog (m) {
+    if (this._paused) {
+      this._buffer.push(m)
+      return
+    }
+    if (this.progressEnabled) {
+      this.gauge.pulse(m.prefix)
+    }
+
+    var l = this.levels[m.level]
+    if (l === undefined) {
+      return
+    }
+
+    if (l < this.levels[this.level]) {
+      return
+    }
+
+    if (l > 0 && !isFinite(l)) {
+      return
+    }
+
+    // If 'disp' is null or undefined, use the lvl as a default
+    // Allows: '', 0 as valid disp
+    var disp = this.disp[m.level]
+    this.clearProgress()
+    m.message.split(/\r?\n/).forEach((line) => {
+      var heading = this.heading
+      if (heading) {
+        this.write(heading, this.headingStyle)
+        this.write(' ')
+      }
+      this.write(disp, this.style[m.level])
+      var p = m.prefix || ''
+      if (p) {
+        this.write(' ')
+      }
+
+      this.write(p, this.prefixStyle)
+      this.write(' ' + line + '\n')
+    })
+    this.showProgress()
+  }
+
+  _format (msg, style) {
+    if (!this.#stream) {
+      return
+    }
+
+    var output = ''
+    if (this.useColor()) {
+      style = style || {}
+      var settings = []
+      if (style.fg) {
+        settings.push(style.fg)
+      }
+
+      if (style.bg) {
+        settings.push('bg' + style.bg[0].toUpperCase() + style.bg.slice(1))
+      }
+
+      if (style.bold) {
+        settings.push('bold')
+      }
+
+      if (style.underline) {
+        settings.push('underline')
+      }
+
+      if (style.inverse) {
+        settings.push('inverse')
+      }
+
+      if (settings.length) {
+        output += consoleControl.color(settings)
+      }
+
+      if (style.beep) {
+        output += consoleControl.beep()
+      }
+    }
+    output += msg
+    if (this.useColor()) {
+      output += consoleControl.color('reset')
+    }
+
+    return output
+  }
+
+  write (msg, style) {
+    if (!this.#stream) {
+      return
+    }
+
+    this.#stream.write(this._format(msg, style))
+  }
+
+  addLevel (lvl, n, style, disp) {
+    // If 'disp' is null or undefined, use the lvl as a default
+    if (disp == null) {
+      disp = lvl
+    }
+
+    this.levels[lvl] = n
+    this.style[lvl] = style
+
+    if (!this[lvl]) {
+      this[lvl] = (...args) => {
+        args.unshift(lvl)
+
+        return this.log.apply(this, args)
+      }
+    }
+    this.disp[lvl] = disp
+  }
 }
 
-log.prefixStyle = { fg: 'magenta' }
-log.headingStyle = { fg: 'white', bg: 'black' }
-
-log.style = {}
-log.levels = {}
-log.disp = {}
-log.addLevel('silly', -Infinity, { inverse: true }, 'sill')
-log.addLevel('verbose', 1000, { fg: 'cyan', bg: 'black' }, 'verb')
-log.addLevel('info', 2000, { fg: 'green' })
-log.addLevel('timing', 2500, { fg: 'green', bg: 'black' })
-log.addLevel('http', 3000, { fg: 'green', bg: 'black' })
-log.addLevel('notice', 3500, { fg: 'cyan', bg: 'black' })
-log.addLevel('warn', 4000, { fg: 'black', bg: 'yellow' }, 'WARN')
-log.addLevel('error', 5000, { fg: 'red', bg: 'black' }, 'ERR!')
-log.addLevel('silent', Infinity)
-
-// allow 'error' prefix
-log.on('error', function () {})
+module.exports = new Log()

--- a/lib/log.js
+++ b/lib/log.js
@@ -156,6 +156,14 @@ class Log extends EventEmitter {
     this.gauge.setTemplate(template)
   }
 
+  trackerRemoveAllListeners () {
+    if (!this.#tracker) {
+      return
+    }
+
+    this.#tracker.removeAllListeners()
+  }
+
   enableProgress () {
     if (this.progressEnabled || this._paused) {
       return

--- a/test/progress.js
+++ b/test/progress.js
@@ -251,3 +251,14 @@ test('pause while enableProgress', function (t) {
   log.resume()
   didActions(t, 'enableProgress', [['enable']])
 })
+
+test('trackerRemoveAllListeners', function (t) {
+  t.plan(2)
+  resetTracker()
+  log.disableProgress()
+  actions = []
+  log.enableProgress()
+  t.equal(log.tracker.listenerCount('change'), 1)
+  log.trackerRemoveAllListeners()
+  t.equal(log.tracker.listenerCount('change'), 0)
+})


### PR DESCRIPTION
This is a very risky PR since it could break a lot of things but I think it is worthy to have.

The loading graph before:
![image](https://github.com/npm/npmlog/assets/12551007/abe2b10c-2924-4a4a-a360-913c84d196ec)

The loading graph after:
![image](https://github.com/npm/npmlog/assets/12551007/ca2c5de2-240b-46f9-ae75-bd392b9c3995)

The loading time using hyperfine before:

```bash
$ hyperfine --warmup 3 "node ./lib/log.js"
Benchmark 1: node ./lib/log.js
  Time (mean ± σ):     114.9 ms ±   1.7 ms    [User: 101.4 ms, System: 37.9 ms]
  Range (min … max):   111.9 ms … 117.6 ms    25 runs
```

After:

```bash
$ hyperfine --warmup 3 "node ./lib/log.js"
Benchmark 1: node ./lib/log.js
  Time (mean ± σ):     104.1 ms ±   2.0 ms    [User: 91.6 ms, System: 34.4 ms]
  Range (min … max):    98.1 ms … 108.5 ms    29 runs

```

I also added another method called `trackerRemoveAllListeners` that can be used to never load the `are-we-there-yet` at https://github.com/npm/cli/blob/latest/lib/utils/display.js#L114

I think we should add more tests to `gauge` and also for `tracker` that didn't include mocked versions since I didn't even declare `tracker` and `gauge` during the tests and it passed all the tests because they are mocked.